### PR TITLE
Fix: multi-db tests issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,9 +100,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-reports
-          path: |
-            tests/coverage
-            tests/reports
+          path: tests/reports
 
   reports:
     name: Report Test Coverages
@@ -114,9 +112,8 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: test-reports
-          path: tests
 
       - name: Report to CodeClimate
         run: |
           curl -LSs $CC_TEST_REPORTER_URL > ./cc-test-reporter && chmod +x ./cc-test-reporter
-          ./cc-test-reporter sum-coverage -o - tests/reports/codeclimate.*.json | ./cc-test-reporter upload-coverage --input -
+          ./cc-test-reporter sum-coverage -o - codeclimate.*.json | ./cc-test-reporter upload-coverage --input -

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd" cacheDirectory="tests/.phpunit.cache" displayDetailsOnSkippedTests="true" displayDetailsOnIncompleteTests="true" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd" cacheDirectory="tests/.cache" displayDetailsOnSkippedTests="true" displayDetailsOnIncompleteTests="true" backupStaticProperties="false">
   <testsuites>
     <testsuite name="Creasi Test Suite">
       <directory>tests</directory>
@@ -8,7 +8,7 @@
   <coverage>
     <report>
       <clover outputFile="tests/reports/clover.xml"/>
-      <html outputDirectory="tests/coverage"/>
+      <html outputDirectory="tests/reports/html"/>
     </report>
   </coverage>
   <logging>

--- a/tests/Models/SampleTest.php
+++ b/tests/Models/SampleTest.php
@@ -14,5 +14,7 @@ class SampleTest extends TestCase
         $model = Sample::factory()->createOne();
 
         $this->assertModelExists($model);
+
+        $this->assertEquals(env('DB_CONNECTION', 'sqlite'), $model->getConnectionName(), 'Should runs on the same connection');
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -31,21 +31,31 @@ class TestCase extends Orchestra
             $config->set('app.locale', 'id');
             $config->set('app.faker_locale', 'id_ID');
 
-            if (env('DB_CONNECTION', 'sqlite')) {
-                $config->set('database.default', 'sqlite');
+            $conn = env('DB_CONNECTION', 'sqlite');
 
-                $database = __DIR__.'/test.sqlite';
+            $config->set('database.default', $conn);
 
-                if (! file_exists($database)) {
+            if ($conn === 'sqlite') {
+                if (! file_exists($database = __DIR__.'/test.sqlite')) {
                     touch($database);
                 }
 
-                $config->set('database.connections.sqlite', [
-                    'driver' => 'sqlite',
+                $this->mergeConfig($config, 'database.connections.sqlite', [
                     'database' => $database,
                     'foreign_key_constraints' => true,
                 ]);
+            } else {
+                $this->mergeConfig($config, 'database.connections.'.$conn, [
+                    'database' => env('DB_DATABASE', 'creasi_test'),
+                    'username' => env('DB_USERNAME', 'creasico'),
+                    'password' => env('DB_PASSWORD', 'secret'),
+                ]);
             }
         });
+    }
+
+    private function mergeConfig(Repository $config, string $key, array $value)
+    {
+        $config->set($key, array_merge($config->get($key, []), $value));
     }
 }


### PR DESCRIPTION
### Notable changes

Berhubung dalam PR ini kita secara eksplisit mendefinisikan konfigurasi database, maka dalam menjalankan pengujian di local masing-masing contributor juga perlu disediakan database khusus untuk pengujian baik untuk `mysql`, `pgsql` maupun driver yang lain.

https://github.com/creasico/laravel-package/blob/19800454cd41bf256b9f26e0fb5fa8153226b19c/tests/TestCase.php#L38-L53

Saat ini pengujian multi database hanya mencakup `mysql`, `pgsql` dan `sqlite`, yang berarti setidaknya perlu menyiapkan database `mysql` dan/atau `pgsql` dengan konfigurasi berikut.

```
DB_DATABASE=creasi_test
DB_USERNAME=creasico
DB_PASSWORD=secret
```

Dan untuk menjalankan pengujian di koneksi database tertentu, gunakan command berikut :

```sh
DB_CONNECTION=pgsql composer test
```

**Note :** command tersebut hanya berlaku untuk *nix shell, untuk pengguna Windows saya lupa caranya 😜 