### PR TITLE
Update dependabot versioning-strategy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @creasico/core

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,9 @@
 version: 2
+
 updates:
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: weekly
-    time: "22:00"
-  open-pull-requests-limit: 10
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    versioning-strategy: lockfile-only


### PR DESCRIPTION
This will make dependabot only updating the lock file instead of whole dependency manager file, in this case is `composer.json`