### PR TITLE
Update dependabot config and enable group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,29 @@ updates:
   - package-ecosystem: composer
     directory: "/"
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
-    versioning-strategy: lockfile-only
+      interval: monthly
+      timezone: "Asia/Jakarta"
+    open-pull-requests-limit: 5
+    versioning-strategy: increase-if-necessary
+    groups:
+      dev-dependencies:
+        patterns:
+          - 'illuminate/*'
+          - 'laravel/*'
+          - 'orchestra/*'
+        update-types: [minor, patch]
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: monthly
+      timezone: "Asia/Jakarta"
+    open-pull-requests-limit: 5
+    versioning-strategy: increase-if-necessary
+    groups:
+      dev-dependencies:
+        patterns:
+          - '@commitlint/*'
+          - 'husky'
+          - 'lint-staged'
+        update-types: [minor, patch]


### PR DESCRIPTION
This is necessary to make dependabot updates in single PR, instead of one update per PR. Not only make it easier to manage, but also it could make less CI runtime.

## Notable changes
- Group updates, see [more info](https://github.blog/changelog/2023-08-24-grouped-version-updates-for-dependabot-are-generally-available/)
- Monthly update schedule instead of Weekly
- Versioning strategy changed to `increase-if-necessary`
